### PR TITLE
Got discover to build and show data in my particular Windows environment

### DIFF
--- a/CommsThread.h
+++ b/CommsThread.h
@@ -27,6 +27,7 @@
 #ifdef _WIN32
     #define WPCAP
     #define HAVE_REMOTE
+    #include <winsock2.h>
     #include <windows.h>
 #endif
 #include <pcap.h>

--- a/Stream.cpp
+++ b/Stream.cpp
@@ -31,7 +31,7 @@
 
 Stream::Stream(QString svID, QString sourceMAC, QObject *parent) : QObject(parent)
 {
-    this->disabled = false; // ADDED BY SHG
+    this->disabled = false;
     this->capturing = true;
     this->alive = true;
     this->checkAlive = false;

--- a/Stream.cpp
+++ b/Stream.cpp
@@ -31,6 +31,7 @@
 
 Stream::Stream(QString svID, QString sourceMAC, QObject *parent) : QObject(parent)
 {
+    this->disabled = false; // ADDED BY SHG
     this->capturing = true;
     this->alive = true;
     this->checkAlive = false;

--- a/rapid61850/svPacketData.h
+++ b/rapid61850/svPacketData.h
@@ -43,7 +43,7 @@ struct ASDU {
 	int showDatset;
 	int showRefrTm;
 	int showSmpRate;
-	struct data {
+    struct struct_data {
 		unsigned char data[SV_MAX_DATASET_SIZE];
 		CTYPE_INT32U size;
 	} data;


### PR DESCRIPTION

I wanted to run a debugger on discover, to see why it wasn't seeing my packets (turns out my multicast address was outside the recommended range), but it wouldn't build.
Visual C++ 2015 (64-bit), Qt 5.12.0 MSVC 2015 64bit
Once I got it running it failed to show any data due to an uninitialized variable.
The CommsThread.h change in particular is probably not optimal -- still gives warnings, but no errors.